### PR TITLE
Fix Lambda runtime errors and update AppSync handler return types

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -29,7 +29,7 @@ resource "aws_lambda_function" "location_handler" {
   filename         = data.archive_file.lambda_zip.output_path
   function_name    = local.function_name_full
   role             = aws_iam_role.lambda_execution_role.arn
-  handler          = "main"
+  handler          = "bootstrap"
   source_code_hash = data.archive_file.lambda_zip.output_base64sha256
   runtime          = var.lambda_runtime
   timeout          = var.lambda_timeout


### PR DESCRIPTION
## Summary
- Fixed `Runtime.InvalidEntrypoint` error by configuring Lambda for `provided.al2023` runtime
- Added support for additional AppSync GraphQL field names
- Updated all handler return types for better GraphQL integration with proper `__typename` fields

## Changes Made

### 🔧 Lambda Runtime Fix
- Updated Makefile to build binary as `bootstrap` (required for `provided.al2023` runtime)
- Updated terraform `lambda.tf` handler configuration to use `bootstrap`
- Resolved `Runtime.InvalidEntrypoint` error that was preventing Lambda execution

### 🔗 AppSync Field Support
- Added support for specific GraphQL mutation field names:
  - `createAddressLocation`, `createCoordinatesLocation` → route to `handleCreateLocation`
  - `updateAddressLocation`, `updateCoordinatesLocation` → route to `handleUpdateLocation`
- Maintains backward compatibility with generic field names (`createLocation`, `updateLocation`)

### 📊 Return Type Updates
- **Create operations**: Return `string` (locationId) instead of `LocationResponse` object
- **Get operation**: Return `map[string]interface{}` with `__typename` field for proper GraphQL type resolution
- **Update operations**: Return `bool` instead of `Location` object  
- **Delete operation**: Return `bool` instead of `DeleteResponse` object
- **List operations**: Return `[]map[string]interface{}` with `__typename` for each location

### 🏷️ GraphQL Type Resolution
- Added `__typename` field to all location responses:
  - `"AddressLocation"` for address-type locations
  - `"CoordinatesLocation"` for coordinates-type locations
- Enables proper GraphQL union/interface type resolution in AppSync

## Test Plan
- [x] Lambda deploys successfully without runtime errors
- [x] AppSync calls with `createAddressLocation` field work correctly
- [x] All operations return expected types with proper `__typename` fields
- [x] Terraform plan/apply completes successfully
- [ ] End-to-end testing with AppSync GraphQL queries

🤖 Generated with [Claude Code](https://claude.ai/code)